### PR TITLE
Update sentaku.ContextualProperty.__get__

### DIFF
--- a/src/sentaku/context.py
+++ b/src/sentaku/context.py
@@ -186,4 +186,4 @@ class ContextualProperty(object):
 
         bound_method = implementation.__get__(instance, type(instance))
         with ctx.use(choice, frozen=True):
-            return bound_method()
+            return bound_method


### PR DESCRIPTION
Return the property value instead of bound method call

Fixes #12

Tested in ManageIQ/Integration_tests repository, with the cfme/base/ui.py definition of the exists method for the 'Zone' object, decorated with `@Zone.exists.external_getter_implemented_for` and `@property`.